### PR TITLE
docs: add ImageData example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,8 @@ bench.txt
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -154,3 +155,6 @@ Temporary Items
 .apdisk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos
+
+# Temporary example image output
+example/*-tmp.*

--- a/example/image-data.js
+++ b/example/image-data.js
@@ -1,0 +1,27 @@
+const { promises } = require('fs')
+const { join } = require('path')
+const PNGReader = require('png.js')
+
+const { createCanvas, ImageData } = require('../index')
+
+const canvas = createCanvas(1024, 768)
+
+const ctx = canvas.getContext('2d')
+
+async function main() {
+  const image = await promises.readFile(join(__dirname, 'tiger.png'))
+  const reader = new PNGReader(image)
+
+  reader.parse(async (err, png) => {
+    if (err) throw err
+
+    const u8array = new Uint8ClampedArray(png.pixels)
+    const data = new ImageData(u8array, png.width, png.height)
+    ctx.putImageData(data, 0, 0)
+
+    const output = await canvas.png()
+    await promises.writeFile(join(__dirname, 'tiger-tmp.png'), output)
+  })
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "husky": "^4.3.6",
     "lint-staged": "^10.5.3",
     "npm-run-all": "^4.1.5",
+    "png.js": "^0.2.1",
     "prettier": "^2.2.1",
     "typescript": "^4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,6 +3231,11 @@ plur@^4.0.0:
   dependencies:
     irregular-plurals "^3.2.0"
 
+png.js@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/png.js/-/png.js-0.2.1.tgz#da6b83c134bdc101940d9ab1c98e9154affbb1f2"
+  integrity sha1-2muDwTS9wQGUDZqxyY6RVK/7sfI=
+
 pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"


### PR DESCRIPTION
This simple example adds [pngjs](https://github.com/arian/pngjs) for JS side PNG decoding. I'm now trying to work on implementing `Image` for `ctx.drawImage`, from my understanding to the roadmap, `Image` should be usable with `decode` that loads binary image files, so pngjs can help bootstraping `Image` class before we have `decode` shipped.

Since I can't install `canvas` both on WSL and macOS Big Sur (neither yarn and npm works, https://github.com/Automattic/node-canvas/issues/1728), the `yarn.lock` is out of sync with `package.json` now. Is it a must to keep it as dev dependency?