### PR TITLE
chore: IDE config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+depot_tools
 skia
 skia-c

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode
 
 # End of https://www.toptal.com/developers/gitignore/api/node
 


### PR DESCRIPTION
This PR fixes the `npm run lint` error, and ignores `.vscode` config files.