### PR TITLE
refactor: remove flush

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -180,11 +180,6 @@ extern "C"
     CANVAS_CAST->clear(static_cast<SkColor>(color));
   }
 
-  void skiac_canvas_flush(skiac_canvas *c_canvas)
-  {
-    CANVAS_CAST->flush();
-  }
-
   void skiac_canvas_set_transform(skiac_canvas *c_canvas, skiac_transform c_ts)
   {
     CANVAS_CAST->setMatrix(conv_from_transform(c_ts));

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -77,7 +77,6 @@ extern "C"
 
   // Canvas
   void skiac_canvas_clear(skiac_canvas *c_canvas, uint32_t color);
-  void skiac_canvas_flush(skiac_canvas *c_canvas);
   void skiac_canvas_set_transform(skiac_canvas *c_canvas, skiac_transform c_ts);
   void skiac_canvas_concat(skiac_canvas *c_canvas, skiac_transform c_ts);
   void skiac_canvas_scale(skiac_canvas *c_canvas, float sx, float sy);

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -140,8 +140,6 @@ mod ffi {
 
     pub fn skiac_canvas_clear(canvas: *mut skiac_canvas, color: u32);
 
-    pub fn skiac_canvas_flush(canvas: *mut skiac_canvas);
-
     pub fn skiac_canvas_set_transform(canvas: *mut skiac_canvas, ts: skiac_transform);
 
     pub fn skiac_canvas_concat(canvas: *mut skiac_canvas, ts: skiac_transform);
@@ -1095,13 +1093,6 @@ impl Canvas {
         self.0,
         (a as u32) << 24 | (r as u32) << 16 | (g as u32) << 8 | b as u32,
       );
-    }
-  }
-
-  #[inline]
-  pub fn flush(&mut self) {
-    unsafe {
-      ffi::skiac_canvas_flush(self.0);
     }
   }
 


### PR DESCRIPTION
With current CPU rendering backend, `flush` has no effect and is unnecessary to be used, since raster drawings are never deferred. Remove its binding reduces unused warning :) See Skia documentation: https://github.com/google/skia/blob/master/include/core/SkCanvas.h#L258

Also to my understanding, using CPU as the raster backend is the is better choice. Because we are not targeting real-time UI rendering, GPU doesn't take advantage here. CPU also scales better for server side cloud hosting.