### PR TITLE
feat: support isPointInStroke

### DIFF
--- a/__test__/draw.spec.ts
+++ b/__test__/draw.spec.ts
@@ -287,7 +287,28 @@ test('getImageData', async (t) => {
 
 test.todo('isPointInPath')
 
-test.todo('isPointInStroke')
+test('isPointInStroke', (t) => {
+  const { ctx } = t.context
+  ctx.rect(10, 10, 100, 100)
+  ctx.stroke()
+  t.is(ctx.isPointInStroke(50, 9), false) // Outside the rect
+  t.is(ctx.isPointInStroke(50, 10), true) // On the edge of the rect
+  t.is(ctx.isPointInStroke(50, 11), false) // Inside the rect
+
+  ctx.lineWidth = 3
+  ctx.stroke()
+  // All points on the edge now
+  t.is(ctx.isPointInStroke(50, 9), true)
+  t.is(ctx.isPointInStroke(50, 10), true)
+  t.is(ctx.isPointInStroke(50, 11), true)
+
+  ctx.lineWidth = 1
+  const path = new Path2D()
+  path.rect(10, 10, 100, 100)
+  t.is(ctx.isPointInStroke(path, 50, 9), false)
+  t.is(ctx.isPointInStroke(path, 50, 10), true)
+  t.is(ctx.isPointInStroke(path, 50, 11), false)
+})
 
 test('lineTo', async (t) => {
   const { ctx } = t.context

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -542,6 +542,31 @@ extern "C"
     return PATH_CAST->isEmpty();
   }
 
+  bool skiac_path_stroke_hit_test(skiac_path *c_path, float x, float y, float stroke_w)
+  {
+    auto path = PATH_CAST;
+    auto prev_fill = path->getFillType();
+    path->setFillType(SkPathFillType::kWinding);
+    SkPaint paint;
+    paint.setStrokeWidth(stroke_w);
+    paint.setStyle(SkPaint::kStroke_Style);
+    SkPath traced_path;
+
+    bool result;
+    auto precision = 0.3; // Based on config in Chromium
+    if (paint.getFillPath(*path, &traced_path, nullptr, precision))
+    {
+      result = traced_path.contains(x, y);
+    }
+    else
+    {
+      result = path->contains(x, y);
+    }
+
+    path->setFillType(prev_fill);
+    return result;
+  }
+
   // PathEffect
 
   skiac_path_effect *skiac_path_effect_make_dash_path(const float *intervals, int count, float phase)

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -156,6 +156,7 @@ extern "C"
   void skiac_path_transform(skiac_path *c_path, skiac_transform c_transform);
   void skiac_path_transform_matrix(skiac_path *c_path, skiac_matrix *c_matrix);
   bool skiac_path_is_empty(skiac_path *c_path);
+  bool skiac_path_stroke_hit_test(skiac_path *c_path, float x, float y, float stroke_w);
 
   // PathEffect
   skiac_path_effect *skiac_path_effect_make_dash_path(const float *intervals, int count, float phase);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -90,6 +90,7 @@ impl Context {
         Property::new(&env, "closePath")?.with_method(close_path),
         Property::new(&env, "createLinearGradient")?.with_method(create_linear_gradient),
         Property::new(&env, "createRadialGradient")?.with_method(create_radial_gradient),
+        Property::new(&env, "isPointInStroke")?.with_method(is_point_in_stroke),
         Property::new(&env, "ellipse")?.with_method(ellipse),
         Property::new(&env, "lineTo")?.with_method(line_to),
         Property::new(&env, "moveTo")?.with_method(move_to),
@@ -623,6 +624,31 @@ fn close_path(ctx: CallContext) -> Result<JsUndefined> {
 
   context_2d.path.close();
   ctx.env.get_undefined()
+}
+
+#[js_function(3)]
+fn is_point_in_stroke(ctx: CallContext) -> Result<JsBoolean> {
+  let this = ctx.this_unchecked::<JsObject>();
+  let context_2d = ctx.env.unwrap::<Context>(&this)?;
+  let mut result = false;
+
+  if ctx.length == 2 {
+    let x: f64 = ctx.get::<JsNumber>(0)?.try_into()?;
+    let y: f64 = ctx.get::<JsNumber>(1)?.try_into()?;
+    let stroke_w = context_2d.states.last().unwrap().paint.get_stroke_width() as f32;
+    result = context_2d
+      .path
+      .stroke_hit_test(x as f32, y as f32, stroke_w);
+  } else if ctx.length == 3 {
+    let path_js = ctx.get::<JsObject>(0)?;
+    let path = ctx.env.unwrap::<Path>(&path_js)?;
+
+    let x: f64 = ctx.get::<JsNumber>(1)?.try_into()?;
+    let y: f64 = ctx.get::<JsNumber>(2)?.try_into()?;
+    let stroke_w = context_2d.states.last().unwrap().paint.get_stroke_width() as f32;
+    result = path.stroke_hit_test(x as f32, y as f32, stroke_w);
+  }
+  ctx.env.get_boolean(result)
 }
 
 #[js_function(8)]

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -334,6 +334,9 @@ mod ffi {
 
     pub fn skiac_path_is_empty(path: *mut skiac_path) -> bool;
 
+    pub fn skiac_path_stroke_hit_test(path: *mut skiac_path, x: f32, y: f32, stroke_w: f32)
+      -> bool;
+
     pub fn skiac_path_effect_make_dash_path(
       intervals: *const f32,
       count: i32,
@@ -1662,6 +1665,11 @@ impl Path {
   #[inline]
   pub fn is_empty(&self) -> bool {
     unsafe { ffi::skiac_path_is_empty(self.0) }
+  }
+
+  #[inline]
+  pub fn stroke_hit_test(&self, x: f32, y: f32, stroke_w: f32) -> bool {
+    unsafe { ffi::skiac_path_stroke_hit_test(self.0, x, y, stroke_w) }
   }
 }
 


### PR DESCRIPTION
This PR supports the `isPointInStroke` API. Quick notes:

* For hit test algorithm and the `0.3` magic number, see https://github.com/samizdatco/skia-canvas/blob/24a2269f8e09e75b467def686f03a61596a72367/native/src/context/mod.rs#L316
* For the underlying Skia API, see https://github.com/google/skia/blob/master/include/core/SkPaint.h#L431
* For test cases, see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/isPointInStroke#examples