### PR TITLE
perf: disable image data copy

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -777,7 +777,7 @@ extern "C"
 
   skiac_bitmap *skiac_bitmap_make_from_buffer(uint8_t *ptr, size_t size)
   {
-    auto data = SkData::MakeWithCopy(reinterpret_cast<const void *>(ptr), size);
+    auto data = SkData::MakeWithoutCopy(reinterpret_cast<const void *>(ptr), size);
     auto codec = SkCodec::MakeFromData(data);
     auto info = codec->getInfo();
     auto row_bytes = info.width() * info.bytesPerPixel();


### PR DESCRIPTION
When `image.src` is set with buffer (whose content is encoded image), this buffer doesn't need to be copied. As long as the SkBitmap is created with that buffer, we keep the reference to the bitmap (whose content is the decoded RGBA bitmap).

However, this also leads to another problem: How to keep the reference to the original buffer? For now (and also previously) I haven't implemented the `let x = image.src` getter. To my understanding to do this, within the `image.src = buffer` setter, we need to keep the reference to the `buffer` JSValue using something like `let data = ctx.get::<JsBuffer>(0)?.into_ref()?` (found in [napi-rs docs](https://napi.rs/concepts/ref)). But if I want to assign this `data` to the `image` struct in Rust, I can't pass the Rust ownership check (this `data` can't be copied). Can I get some hints or working examples about how to do this? Thanks.